### PR TITLE
fix: Fix camera not centering on user and dpad not showing

### DIFF
--- a/lib/talacare.dart
+++ b/lib/talacare.dart
@@ -27,7 +27,9 @@ class TalaCare extends FlameGame with HasKeyboardHandlerComponents {
 
     cam = CameraComponent(world: world);
     cam.viewfinder.anchor = Anchor.center;
-    cam.viewport = FixedSizeViewport(300, 600);
+    cam.viewfinder.zoom = 3;
+    cam.viewport = FixedAspectRatioViewport(aspectRatio: 0.5625);
+    
     cam.follow(player);
 
     final Image dPadImage = await images.load('D_Pad/D-Pad.png');


### PR DESCRIPTION
- Fixed bug where camera doesn't center on user by changing the viewfinder anchor
- Fixed bug where player can't see the dpad because it's offscreen as the dpad moves around based on set screen size by changing from fixed resolution viewport to fixed size viewport